### PR TITLE
fix(main): remove obsolete CLI flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,10 +15,9 @@ import (
 )
 
 const (
-	APITokenFlag       = "api-token"
-	BindAddressFlag    = "bind-address"
-	ScrapeIntervalFlag = "scrape-interval"
-	PageSizeFlag       = "page-size"
+	APITokenFlag    = "api-token"
+	BindAddressFlag = "bind-address"
+	PageSizeFlag    = "page-size"
 )
 
 var (
@@ -40,12 +39,6 @@ var (
 			Usage:   "The number of monitors to request per page (max 250).",
 			Value:   50,
 			EnvVars: []string{strcase.ToScreamingSnake(PageSizeFlag)},
-		},
-		&cli.IntFlag{
-			Name:    ScrapeIntervalFlag,
-			Usage:   "The interval in seconds between scraping of monitor statuses.",
-			Value:   60,
-			EnvVars: []string{strcase.ToScreamingSnake(ScrapeIntervalFlag)},
 		},
 	}
 )


### PR DESCRIPTION
# Description

- CLI flag `scrape-interval` has been made obsolete, remove it from `cmd/main.go`

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR